### PR TITLE
feat: Add new staff and combat divisions to the seeding script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ my-turborepo/
 
 # VS Code editor settings (keep local)
 .vscode/
+DiscordRoles.xlsx

--- a/packages/database/scripts/seed-ranks-and-divisions.js
+++ b/packages/database/scripts/seed-ranks-and-divisions.js
@@ -16,12 +16,17 @@ const divisions = [
     ["SPR", "S.P.E.A.R.", "combat", true, "SPR | "],
     ["HVK", "H.A.V.O.K.", "combat", true, "HVK | "],
     ["RFT", "R.A.F.T.", "combat", true, "RFT | "],
+    ["RPR", "R.E.A.P.E.R.", "combat", true, "RPR | "],
     ["DRL", "D.R.I.L.L.", "industrial", false, "DRL | "],
     ["SCR", "S.C.R.A.P.", "industrial", false, "SCR | "],
     ["LOG", "L.O.G.I.", "industrial", false, "LOG | "],
     ["TRD", "T.R.A.D.E.", "industrial", false, "TRD | "],
     ["ARC", "A.R.C.H.", "industrial", false, "ARC | "],
-    ["RPR", "R.E.A.P.E.R.", "combat", true, "RPR | "],
+    ["SEC", "Security", "staff", false, "SEC | "],
+    ["ADMR", "Admiral", "staff", false, "ADMR | "],
+    ["CMDR", "Commander", "staff", false, "CMDR | "],
+    ["TECH", "Tech Dept.", "staff", false, "TECH | "],
+    ["EXEC", "Executive", "staff", false, "EXEC | "]
 ];
 
 async function main() {


### PR DESCRIPTION
### Summary
- extend `packages/database/scripts/seed-ranks-and-divisions.js` with the new combat division **RPR** and the staff divisions **SEC**, **ADMR**, **CMDR**, **TECH**, and **EXEC**
- keep `DiscordRoles.xlsx` out of version control since that's a discord-dependent file

### Testing
- [ ] `pnpm --filter @workspace/database run seed:ranks` *(or equivalent)*  
  _(Not run yet — please execute on the target environment to verify the new divisions seed correctly.)_

### Notes
- existing environments will need the updated seed script executed to backfill the new roles in the database
- once seeded, make sure Discord role IDs are aligned with the `division` records if automation depends on them