### PR TITLE
[DO NOT MERGE] Remove Raft and Spear divisions

### DIFF
--- a/apps/arbiter/docs/rank-sync.md
+++ b/apps/arbiter/docs/rank-sync.md
@@ -111,9 +111,9 @@ Both `/rank sync` and `/rank sync-all` now show a review screen before any chang
 - After Apply/Cancel, the UI is cleared to avoid stale interactions.
 
 ## Parsing legacy nicknames (backfill)
-When users already have decorated nicknames (e.g., `RFT | Sigeth ①`, `HVK ◇ | quin ①`), the sync logic:
+When users already have decorated nicknames (e.g., `VNG | Sigeth ①`, `HVK ◇ | quin ①`), the sync logic:
 
-- Strips known rank symbols (◇, ⬖, ◆ and circled digits) and detects a division by matching either the configured `nicknamePrefix` (e.g., `RFT |`) or the division `code` at the start.
+- Strips known rank symbols (◇, ⬖, ◆ and circled digits) and detects a division by matching either the configured `nicknamePrefix` (e.g., `VNG |`) or the division `code` at the start.
 - Extracts a clean base name (e.g., `Sigeth`) and uses it to backfill `preferredName` if it’s missing.
 - If a division (combat or staff) is detected and the user lacks DivisionMembership, a membership is backfilled for that division.
 - Hidden divisions are respected: if the selected division has `showRank = false` and is `kind = 'staff'`, we still perform a prefix-only update; otherwise, no nickname change is applied.

--- a/apps/arbiter/src/app/commands/post-division-message/post-division-message.ts
+++ b/apps/arbiter/src/app/commands/post-division-message/post-division-message.ts
@@ -11,7 +11,8 @@ import {
 } from "discord.js";
 import { forInteraction } from "@workspace/logger";
 import { Division, prisma } from "@workspace/db";
-import { CONFIG } from "../../config";
+
+import { CONFIG, DIVISION_ROLES } from "../../config";
 
 type DivisionWithEmoji = Division & { emojiId: string; emojiName: string };
 
@@ -20,10 +21,6 @@ const COMBAT_DESCRIPTIONS: Record<string, string[]> = {
 		"**High-Altitude Lethal Overwatch** - H.A.L.O. is Even Legion's elite fighter squadron. These pilots dominate the skies through fierce engagement and superior air control, ensuring aerial superiority in every conflict.",
 		"\nIn this Division, you might: fly high-speed fighters/interceptors, engage enemy squadrons, or serve as air cover in coordinated ops.",
 	],
-	SPR: [
-		"**Specialized Extraction and Reconnaissance** - S.P.E.A.R. is the Legion's eyes in the dark. Masters of infiltration, tracking, and elimination, they strike with precision - or observe silently until the time is right.",
-		"\nIn this Division, you might: scan for threats, perform intel runs, execute black ops, or sabotage key assets.",
-	],
 	VNG: [
 		"**Vehicle & Ground Unity Armed Deployment** - V.A.N.G.U.A.R.D. is the Legion's ground combat core. Vanguard leads bunker breaches, vehicle assaults, and frontline raids. Whether it's boots in the dirt or tanks on the move, they're our hammer on the ground.",
 		"\nIn this Division, you might: clear bunkers, operate tanks or transports, hold fortified positions, and assault, clear, and hold key locations.",
@@ -31,10 +28,6 @@ const COMBAT_DESCRIPTIONS: Record<string, string[]> = {
 	HVK: [
 		"**Heavy Air Support & Variable Ordnance** - H.A.V.O.K. is our multi-crew gunship and heavy-class strike unit. Operating between air and ground, they bring firepower and flexibility to escort, overwatch, and support combat teams in hostile zones.",
 		"\nIn this Division, you might: crew a gunship, escort dropships, take out enemy capital ships, or support divisions on the ground and in the air.",
-	],
-	RFT: [
-		"**Rapid Aid & Field Triage** - R.A.F.T. is the Legion's fearless medical rescue unit. From reviving wounded soldiers to coordinating medical extractions, these responders keep the fight alive.",
-		"\nIn this Division, you might: work as combat medics, deploy with search and rescue teams, or stabilize critical players in high-pressure engagements.",
 	],
 };
 
@@ -134,9 +127,15 @@ export async function chatInput({ interaction }: ChatInputCommandContext) {
 async function fetchDivisionsWithEmojis(
 	divisionType: "combat" | "industrial"
 ): Promise<DivisionWithEmoji[]> {
+	const allowedCodes =
+		divisionType === "combat"
+			? Object.keys(DIVISION_ROLES.combat)
+			: Object.keys(DIVISION_ROLES.industrial);
+
 	return (await prisma.division.findMany({
 		where: {
 			kind: { equals: divisionType, mode: "insensitive" },
+			code: { in: allowedCodes },
 			AND: [{ emojiId: { not: null } }, { emojiName: { not: null } }],
 		},
 		orderBy: { id: "asc" },

--- a/apps/arbiter/src/app/config.ts
+++ b/apps/arbiter/src/app/config.ts
@@ -26,9 +26,7 @@ export const DIVISION_ROLES = isDev() ? {
   combat: {
     HLO: process.env.DEV_HALO_ROLE_ID ?? "", // H.A.L.O. (dev)
     VNG: process.env.DEV_VANGUARD_ROLE_ID ?? "", // V.A.N.G.U.A.R.D. (dev)
-    SPR: process.env.DEV_SPEAR_ROLE_ID ?? "", // S.P.E.A.R. (dev)
     HVK: process.env.DEV_HAVOK_ROLE_ID ?? "", // H.A.V.O.K. (dev)
-    RFT: process.env.DEV_RAFT_ROLE_ID ?? "", // R.A.F.T. (dev)
   },
   industrial: {
     DRL: process.env.DEV_DRILL_ROLE_ID ?? "", // D.R.I.L.L. (dev)
@@ -42,9 +40,7 @@ export const DIVISION_ROLES = isDev() ? {
   combat: {
     HLO: "1356438908212088863", // H.A.L.O.
     VNG: "1356438093988757686", // V.A.N.G.U.A.R.D.
-    SPR: "1356438285592825989", // S.P.E.A.R.
     HVK: "1362489356958437477", // H.A.V.O.K.
-    RFT: "1356438213438472323", // R.A.F.T.
   },
   industrial: {
     DRL: "1356458993056485477", // D.R.I.L.L.

--- a/apps/arbiter/src/app/scripts/migrate-divisions.ts
+++ b/apps/arbiter/src/app/scripts/migrate-divisions.ts
@@ -193,12 +193,24 @@ async function updateDiscordAndNicknames(
 			if (!dryRun) {
 				// Remove legacy role, add target role, then sync nickname
 				if (hasFrom) {
-					await member.roles.remove(fromRoleId);
+					try {
+						await member.roles.remove(fromRoleId);
+					} catch (err) {
+						console.warn(`[roles] failed to remove ${from} from ${userId}: ${String((err as any)?.message ?? err)}`);
+					}
 				}
 				if (!hasTo) {
-					await member.roles.add(toRoleId);
+					try {
+						await member.roles.add(toRoleId);
+					} catch (err) {
+						console.warn(`[roles] failed to add ${to} to ${userId}: ${String((err as any)?.message ?? err)}`);
+					}
 				}
-				await syncNicknameAuto({ guild, userID: userId });
+				try {
+					await syncNicknameAuto({ guild, userID: userId });
+				} catch (err) {
+					console.warn(`[nickname] failed for ${userId}: ${String((err as any)?.message ?? err)}`);
+				}
 			}
 
 			syncCount++;
@@ -263,11 +275,10 @@ async function main() {
 
 			await client.login(DISCORD_TOKEN);
 			await updateDiscordAndNicknames(client, GUILD_ID, affectedUsers);
+			await deleteLegacyDivisions();
 		} else {
 			console.log("Discord env not set; skipping role updates and nickname sync.");
 		}
-
-		await deleteLegacyDivisions();
 	} finally {
 		if (client) {
 			await client.destroy();

--- a/apps/arbiter/src/app/scripts/migrate-divisions.ts
+++ b/apps/arbiter/src/app/scripts/migrate-divisions.ts
@@ -1,0 +1,288 @@
+import { Client, GatewayIntentBits } from "discord.js";
+import { prisma } from "@workspace/db";
+
+import { syncNicknameAuto } from "../services/rankSync.ts";
+
+type DivisionCode = "SPR" | "RFT" | "HLO" | "VNG";
+
+type MigrationSpec = {
+	from: DivisionCode;
+	to: DivisionCode;
+};
+
+// Map legacy divisions to their new targets.
+const MIGRATIONS: MigrationSpec[] = [
+	{ from: "SPR", to: "HLO" },
+	{ from: "RFT", to: "VNG" },
+];
+
+const argv = process.argv.slice(2);
+const hasFlag = (flag: string) => argv.includes(flag);
+const dryRun = hasFlag("--dry-run");
+
+
+const env = (process.env.ENVIRONMENT || process.env.NODE_ENV || "production").toLowerCase();
+const isDev = ["dev", "development", "local"].includes(env);
+
+const DISCORD_TOKEN =
+	process.env.DISCORD_TOKEN ||
+	process.env.BOT_TOKEN ||
+	process.env.TOKEN ||
+	"";
+const GUILD_ID =
+	process.env.DISCORD_GUILD_ID ||
+	process.env.GUILD_ID ||
+	"";
+
+const PROD_ROLE_IDS: Record<DivisionCode, string> = {
+	HLO: "1356438908212088863",
+	VNG: "1356438093988757686",
+	SPR: "1356438285592825989",
+	RFT: "1356438213438472323",
+};
+
+const DEV_ROLE_IDS: Record<DivisionCode, string> = {
+	HLO: process.env.DEV_HALO_ROLE_ID ?? "",
+	VNG: process.env.DEV_VANGUARD_ROLE_ID ?? "",
+	SPR: process.env.DEV_SPEAR_ROLE_ID ?? "",
+	RFT: process.env.DEV_RAFT_ROLE_ID ?? "",
+};
+
+const ROLE_IDS = isDev ? DEV_ROLE_IDS : PROD_ROLE_IDS;
+
+function requireRoleId(code: DivisionCode): string {
+	const id = ROLE_IDS[code];
+	if (!id) {
+		throw new Error(
+			`Missing role ID for ${code}. Set ${isDev ? "DEV_*_ROLE_ID" : "production role IDs"} before running.`
+		);
+	}
+	return id;
+}
+
+/**
+ * Step 1: Update divisionMemberships in the DB.
+ * - Remove duplicate legacy memberships where target already exists.
+ * - Move remaining legacy memberships to target divisions.
+ * - Validate no legacy memberships remain.
+ */
+async function migrateMemberships() {
+	console.log(`=== Migrating Memberships ===`);
+
+	const codes: DivisionCode[] = ["SPR", "RFT", "HLO", "VNG"];
+	const divisions = await prisma.division.findMany({ where: { code: { in: codes } } });
+	const byCode = new Map(divisions.map((d) => [d.code as DivisionCode, d]));
+
+	for (const code of codes) {
+		if (!byCode.has(code)) {
+			throw new Error(`Division ${code} not found in DB. Aborting.`);
+		}
+	}
+
+	const affectedUsers = new Map<DivisionCode, Set<string>>();
+
+	for (const { from, to } of MIGRATIONS) {
+		const fromDiv = byCode.get(from)!;
+		const toDiv = byCode.get(to)!;
+
+		// Current memberships for legacy division
+		const fromMemberships = await prisma.divisionMembership.findMany({
+			where: { divisionId: fromDiv.id },
+			select: { userId: true },
+		});
+		// Current memberships for target division
+		const toMemberships = await prisma.divisionMembership.findMany({
+			where: { divisionId: toDiv.id },
+			select: { userId: true },
+		});
+
+		const toSet = new Set(toMemberships.map((m) => m.userId));
+		// Users already in target division; drop legacy membership
+		const duplicates = fromMemberships.filter((m) => toSet.has(m.userId));
+		// Users only in legacy division; move to target division
+		const toMove = fromMemberships.filter((m) => !toSet.has(m.userId));
+
+		affectedUsers.set(from, new Set(fromMemberships.map((m) => m.userId)));
+
+		console.log(
+			`${from} -> ${to}: total=${fromMemberships.length} ` +
+			`duplicates=${duplicates.length} toMove=${toMove.length}`
+		);
+
+		if (dryRun) {
+			continue;
+		}
+
+		if (duplicates.length > 0) {
+			// Remove duplicate legacy memberships
+			await prisma.divisionMembership.deleteMany({
+				where: {
+					divisionId: fromDiv.id,
+					userId: { in: duplicates.map((m) => m.userId) },
+				},
+			});
+		}
+
+		if (toMove.length > 0) {
+			// Repoint legacy memberships to target division
+			await prisma.divisionMembership.updateMany({
+				where: {
+					divisionId: fromDiv.id,
+					userId: { in: toMove.map((m) => m.userId) },
+				},
+				data: {
+					divisionId: toDiv.id,
+					lastComputedAt: new Date(),
+				},
+			});
+		}
+	}
+
+	if (dryRun) {
+		return { affectedUsers };
+	}
+
+	// Verify legacy memberships are cleared before cleanup.
+	for (const { from } of MIGRATIONS) {
+		const div = byCode.get(from)!;
+		const remaining = await prisma.divisionMembership.count({ where: { divisionId: div.id } });
+		if (remaining > 0) {
+			throw new Error(
+				`Validation failed: ${remaining} memberships still reference ${from}. Aborting cleanup.`
+			);
+		}
+	}
+
+	return { affectedUsers };
+}
+
+/**
+ * Step 2: Swap Discord roles and sync nicknames for affected users.
+ */
+async function updateDiscordAndNicknames(
+	client: Client,
+	guildId: string,
+	affectedUsers: Map<DivisionCode, Set<string>>
+) {
+	console.log(`=== Migrating Discord Roles + Nickname Sync ===`);
+
+	const guild = await client.guilds.fetch(guildId);
+
+	for (const { from, to } of MIGRATIONS) {
+		const fromRoleId = requireRoleId(from);
+		const toRoleId = requireRoleId(to);
+		const users = Array.from(affectedUsers.get(from) ?? []);
+		let missing = 0;
+		let addCount = 0;
+		let removeCount = 0;
+		let syncCount = 0;
+
+		for (const userId of users) {
+			const member = await guild.members.fetch(userId).catch(() => null);
+			if (!member) {
+				missing++;
+				continue;
+			}
+
+			const hasFrom = member.roles.cache.has(fromRoleId);
+			const hasTo = member.roles.cache.has(toRoleId);
+
+			if (hasFrom) removeCount++;
+			if (!hasTo) addCount++;
+
+			if (!dryRun) {
+				// Remove legacy role, add target role, then sync nickname
+				if (hasFrom) {
+					await member.roles.remove(fromRoleId);
+				}
+				if (!hasTo) {
+					await member.roles.add(toRoleId);
+				}
+				await syncNicknameAuto({ guild, userID: userId });
+			}
+
+			syncCount++;
+		}
+
+		console.log(
+			`${from} -> ${to}: users=${users.length} add=${addCount} remove=${removeCount} ` +
+			`missing=${missing} nickSync=${syncCount}`
+		);
+	}
+}
+
+/**
+ * Step 3: Delete SPR/RFT from the division table once memberships are cleared.
+ */
+async function deleteLegacyDivisions() {
+	console.log(`=== Deleting Legacy Divisions ===`);
+
+	if (dryRun) {
+		console.log("Dry run: skipping division deletion.");
+		return;
+	}
+
+	const codes: DivisionCode[] = ["SPR", "RFT"];
+	const remaining = await prisma.divisionMembership.count({
+		where: { division: { code: { in: codes } } },
+	});
+	if (remaining > 0) {
+		throw new Error(
+			`Refusing to delete divisions; ${remaining} memberships still reference SPR/RFT.`
+		);
+	}
+
+	const deleted = await prisma.division.deleteMany({ where: { code: { in: codes } } });
+	console.log(`Deleted ${deleted.count} legacy divisions.`);
+}
+
+/**
+ * Orchestrates the migration:
+ * 1) DB membership updates
+ * 2) Discord role swap + nickname sync
+ * 3) Legacy division cleanup
+ */
+async function main() {
+	console.log(`Division migration ${dryRun ? "(dry-run)" : "(live)"} env=${env}`);
+
+	if (!dryRun && (!DISCORD_TOKEN || !GUILD_ID)) {
+		throw new Error("DISCORD_TOKEN and DISCORD_GUILD_ID (or GUILD_ID) are required.");
+	}
+
+	const { affectedUsers } = await migrateMemberships();
+
+	let client: Client | null = null;
+	try {
+		if (DISCORD_TOKEN && GUILD_ID) {
+			client = new Client({
+				intents: [
+					GatewayIntentBits.Guilds,
+					GatewayIntentBits.GuildMembers,
+				],
+			});
+
+			await client.login(DISCORD_TOKEN);
+			await updateDiscordAndNicknames(client, GUILD_ID, affectedUsers);
+		} else {
+			console.log("Discord env not set; skipping role updates and nickname sync.");
+		}
+
+		await deleteLegacyDivisions();
+	} finally {
+		if (client) {
+			await client.destroy();
+		}
+	}
+}
+
+main()
+	.then(() => {
+		console.log("Done.");
+	})
+	.catch(async (err) => {
+		console.error(err);
+		process.exitCode = 1;
+	})
+	.finally(async () => {
+		await prisma.$disconnect();
+	});

--- a/packages/database/scripts/seed-ranks-and-divisions.js
+++ b/packages/database/scripts/seed-ranks-and-divisions.js
@@ -20,9 +20,7 @@ const divisions = [
     "VANG_Emblem",
     "1370272690623217664",
   ],
-  ["SPR", "S.P.E.A.R.", "combat", true, "SPR | ", "SPR_Emblem", "1370272692267389018"],
   ["HVK", "H.A.V.O.K.", "combat", true, "HVK | ", "HVK_Emblem", "1370272695308259398"],
-  ["RFT", "R.A.F.T.", "combat", true, "RFT | ", "RAFT_Emblem", "1374196910151176273"],
   ["RPR", "R.E.A.P.E.R.", "combat", true, "RPR | ", null, null],
   [
     "DRL",


### PR DESCRIPTION
We should not merge this PR until we're ready to remove the Spear and Raft divisions

- Removes RFT and SPR from:
    - `apps/arbiter/docs/rank-sync.md`
    - `apps/arbiter/src/app/commands/post-division-message/post-division-message.ts`
    - `apps/arbiter/src/app/config.ts`
    - `packages/database/scripts/seed-ranks-and-divisions.js`
- Creates `apps/arbiter/src/app/scripts/migrate-divisions.ts` which is a script we can run on the VPS the bot is deployed to which will:
    - Migrate all Spear members to Halo, and all Raft to Vanguard
    - Validate no users remain with these divisions
    - Remove Spear/Raft Discord roles and add Halo/Vanguard for each user, then run rankSync
    - Delete Spear and Raft from Divisions table