### PR TITLE
Add a check if user has a lance memership, if so use it

### DIFF
--- a/apps/arbiter/src/app/services/rankSync.ts
+++ b/apps/arbiter/src/app/services/rankSync.ts
@@ -143,8 +143,8 @@ async function pickDisplayDivision(userID: string) {
 	const memberships = await prisma.divisionMembership.findMany({ where: { userId: userID }, include: { division: true } });
 	log.debug({ memberships: memberships.map(m => ({ code: m.division.code, kind: m.division.kind, showRank: m.division.showRank })) }, "pickDisplayDivision");
 
-	// If user has a Lance division membership (code ending in -L), prefer it.
-	const lance = memberships.find(m => String(m.division.code).toUpperCase().endsWith("-L"));
+	// If user has a Lance division membership (code ending in -L), prefer it (with visible rank).
+	const lance = memberships.find(m => String(m.division.code).toUpperCase().endsWith("-L") && m.division.showRank);
 	if (lance) return lance.division;
 
 	// Priority: combat > industrial > null

--- a/apps/arbiter/src/app/services/rankSync.ts
+++ b/apps/arbiter/src/app/services/rankSync.ts
@@ -143,6 +143,10 @@ async function pickDisplayDivision(userID: string) {
 	const memberships = await prisma.divisionMembership.findMany({ where: { userId: userID }, include: { division: true } });
 	log.debug({ memberships: memberships.map(m => ({ code: m.division.code, kind: m.division.kind, showRank: m.division.showRank })) }, "pickDisplayDivision");
 
+	// If user has a Lance division membership (code ending in -L), prefer it.
+	const lance = memberships.find(m => String(m.division.code).toUpperCase().endsWith("-L"));
+	if (lance) return lance.division;
+
 	// Priority: combat > industrial > null
 	// Prefer combat with visible rank (highest priority)
 	const combat = memberships.find(m => String(m.division.kind).toLowerCase() === "combat" && m.division.showRank);


### PR DESCRIPTION
Without this, members with both combat/industrial division and Lance will always have their nickname updated to be the non-Lance division since `pickDisplayDivision` isn't even aware Lance roles exist